### PR TITLE
Removed double line-end at the end of @import insertion

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -62,7 +62,7 @@ if($('body.about, body.thankyou').length < 1 ) {
 
   $('[data-import]').on('click', function(event) {
     var imports = $(this).data('import').split(','),
-        eol = ( SassMeister.inputs.sass.syntax == 'SCSS' ? ';' : '' ) + '\n\n';
+        eol = ( SassMeister.inputs.sass.syntax == 'SCSS' ? ';' : '' ) + '\n';
 
     $(imports).each(function() {      
       SassMeister.editors.sass.insert( '@import "' + this + '"' + eol);


### PR DESCRIPTION
By adding double line-end one's unable to create @imports blocks without manually removing unnecessary spacing.
