### PR TITLE
Use spaces instead of hard tabs, Tab key inserts 2 spaces

### DIFF
--- a/public/javascripts/SassMeister.js
+++ b/public/javascripts/SassMeister.js
@@ -144,6 +144,9 @@ var SassMeister;
 
       input.setTheme('ace/theme/tomorrow');
       input.getSession().setMode('ace/mode/' + syntax.toLowerCase());
+      
+      input.getSession().setTabSize(2);
+      input.getSession().setUseSoftTabs(true);
 
       input.setValue(value);
       input.clearSelection();


### PR DESCRIPTION
Ace editor's default is using hard, 4 space-wide tabs.

Sass and Haml most commonly follow the Ruby standard of soft, 2 space-wide tabs.

https://github.com/styleguide/css
https://github.com/styleguide/ruby
