### PR TITLE
Remove double scrollbar on editors

### DIFF
--- a/sass/modules/_editors.scss
+++ b/sass/modules/_editors.scss
@@ -56,7 +56,7 @@
   .touch & {
     .ace_scroller {
       -webkit-overflow-scrolling: touch !important;
-      overflow-y: scroll !important;
+      // overflow-y: scroll !important;
     }
   }
 }


### PR DESCRIPTION
The property "overflow-y: scroll !important" in the CSS rule .touch .main_body .ace_scroller is causing two scrollbars to appear...one of which is completely pointless. Simply removing this line fixes the problem.