### PR TITLE
Update the LibSass url

### DIFF
--- a/client/sassmeister/states/about/_about.jade
+++ b/client/sassmeister/states/about/_about.jade
@@ -20,7 +20,7 @@ body
       | , 
       a(href='http://compass-style.org/') Compass
       | , and 
-      a(href='http://libsass.org/') LibSass
+      a(href='http://sass-lang.com/libsass') LibSass
       | . Add some Sass and SassMeister will show you the rendered CSS. SassMeister supports both 
       a(href='http://thesassway.com/articles/sass-vs-scss-which-syntax-is-better') Sass and SCSS syntaxes
       | , all 


### PR DESCRIPTION
Since it's now part of (and redirects to) the Sass-Lang website
